### PR TITLE
Add assertions to Parser and TaskList

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ application {
 
 shadowJar {
     archiveBaseName = "Yapper"
-    archiveVersion = "v0.03"
+    archiveVersion = "v0.06"
     archiveClassifier = null
     dependsOn("distZip", "distTar")
 }

--- a/src/main/java/yapper/Parser.java
+++ b/src/main/java/yapper/Parser.java
@@ -53,6 +53,7 @@ public class Parser {
         switch (cmd) {
         case BYE:
             try {
+                assert(fm != null);
                 fm.saveTasks();
             } catch (YapperException y) {
                 response = y.getMessage();

--- a/src/main/java/yapper/TaskList.java
+++ b/src/main/java/yapper/TaskList.java
@@ -79,6 +79,7 @@ public class TaskList {
     public String markTask(int i) {
         Task task = tasks.get(i - 1);
         task.markAsDone();
+        assert(ui != null);
         return ui.markMessage(task);
     }
 
@@ -90,6 +91,7 @@ public class TaskList {
     public String unmarkTask(int i) {
         Task task = tasks.get(i - 1);
         task.unmark();
+        assert(ui != null);
         return ui.unmarkMessage(task);
     }
 
@@ -101,6 +103,7 @@ public class TaskList {
     public String deleteTask(int i) {
         Task task = tasks.get(i - 1);
         tasks.remove(i - 1);
+        assert(ui != null);
         return ui.deleteMessage(task);
     }
 


### PR DESCRIPTION
Parser and TaskList classes have no checks that their references to FileManager and Ui instances are properly assigned.

This can lead to a possible NullPointerException in the future if the way the references are set changes.

Add assertions that references are not null before calling them in methods.